### PR TITLE
Remove getRelativeHref and update positionsByHref

### DIFF
--- a/src/model/Publication.ts
+++ b/src/model/Publication.ts
@@ -166,14 +166,6 @@ export default class Publication {
   public getAbsoluteHref(href: string): string | null {
     return new URL(href, this.manifestUrl.href).href;
   }
-  public getRelativeHref(href: string): string | null {
-    const manifest = this.manifestUrl.href.replace("/manifest.json", ""); //new URL(this.manifestUrl.href, this.manifestUrl.href).href;
-    var href = href.replace(manifest, "");
-    if (href.charAt(0) === "/") {
-      href = href.substring(1);
-    }
-    return href;
-  }
 
   public getTOCItemAbsolute(href: string): Link | null {
     const absolute = this.getAbsoluteHref(href);
@@ -244,7 +236,8 @@ export default class Publication {
   /**
    * positionsByHref
    */
-  public positionsByHref(href: string) {
-    return this.positions.filter((el: Locator) => el.href === decodeURI(href));
+  public positionsByHref(href: string): Locator[] {
+    const decodedHref = decodeURI(href) ?? "";
+    return this.positions.filter((p: Locator) => decodedHref.includes(p.href));
   }
 }

--- a/src/modules/AnnotationModule.ts
+++ b/src/modules/AnnotationModule.ts
@@ -241,11 +241,8 @@ export default class AnnotationModule implements ReaderModule {
           this.publication.positions) ||
         this.publication.positions
       ) {
-        const positions = this.publication.positionsByHref(
-          this.publication.getRelativeHref(
-            this.delegate.currentChapterLink.href
-          )
-        );
+        const chptHref: string = this.delegate.currentChapterLink.href;
+        const positions = this.publication.positionsByHref(chptHref);
         const positionIndex = Math.ceil(progression * (positions.length - 1));
         const locator = positions[positionIndex];
 

--- a/src/modules/BookmarkModule.ts
+++ b/src/modules/BookmarkModule.ts
@@ -204,11 +204,8 @@ export default class BookmarkModule implements ReaderModule {
           this.publication.positions) ||
         this.publication.positions
       ) {
-        const positions = this.publication.positionsByHref(
-          this.publication.getRelativeHref(
-            this.delegate.currentChapterLink.href
-          )
-        );
+        const chptHref: string = this.delegate.currentChapterLink.href;
+        const positions = this.publication.positionsByHref(chptHref);
         const positionIndex = Math.ceil(progression * (positions.length - 1));
         const locator = positions[positionIndex];
 

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -2127,7 +2127,7 @@ export default class IFrameNavigator implements Navigator {
     return this.publication.readingOrder.length;
   }
   mostRecentNavigatedTocItem(): string {
-    return this.publication.getRelativeHref(this.currentTOCRawLink);
+    return this.currentTOCRawLink;
   }
   currentResource(): number {
     let currentLocation = this.currentChapterLink.href;
@@ -2186,13 +2186,14 @@ export default class IFrameNavigator implements Navigator {
       this.publication.positions
     ) {
       let positions = this.publication.positionsByHref(
-        this.publication.getRelativeHref(this.currentChapterLink.href)
+        this.currentChapterLink.href
       );
       let positionIndex = Math.ceil(
         this.view.getCurrentPosition() * (positions.length - 1)
       );
       position = positions[positionIndex];
-    } else {
+    }
+    if (!position) {
       var tocItem = this.publication.getTOCItem(this.currentChapterLink.href);
       if (this.currentTocUrl !== null) {
         tocItem = this.publication.getTOCItem(this.currentTocUrl);
@@ -2913,9 +2914,7 @@ export default class IFrameNavigator implements Navigator {
           this.publication.positions) ||
         this.publication.positions
       ) {
-        const positions = this.publication.positionsByHref(
-          this.publication.getRelativeHref(tocItem.href)
-        );
+        const positions = this.publication.positionsByHref(tocItem.href);
         const positionIndex = Math.ceil(
           locations.progression * (positions.length - 1)
         );


### PR DESCRIPTION
The function `getRelativeHref` currently assumes that our "manifestUrl" matches a certain pattern. Our manifestUrl doesn't meet this assumption however, and the result is that `getRelativeHref` fails to transform the given `href` into a "relative" href. 

This function was used in part to determine the user's "location" in several different modules (Navigator, Bookmarks, Annotations), and it was leading to "location" being `undefined`.

I fixed this by removing the `getRelativeHref` entirely and in order to remove the code's dependency on the manifestUrl matching a specific pattern. `getRelativeHref` isn't really needed. I updated `positionsByHref` to not need a "relative" href in order to work. 

 