### PR TITLE
Changed readerLoading to a fn and added message

### DIFF
--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -533,7 +533,7 @@ export default class IFrameNavigator implements Navigator {
         "#reader-loading"
       ) as HTMLDivElement;
       if (this.loadingMessage) {
-        this.loadingMessage.innerHTML = getReaderLoading();
+        this.loadingMessage.innerHTML = getReaderLoading('Pulling your book from the shelf...');
         this.loadingMessage.style.display = "none"; 
       }
       this.errorMessage = HTMLUtilities.findElement(

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -28,7 +28,7 @@ import * as BrowserUtilities from "../utils/BrowserUtilities";
 import * as HTMLUtilities from "../utils/HTMLUtilities";
 import {
   readerError,
-  readerLoading,
+  getReaderLoading,
   simpleUpLinkTemplate,
 } from "../utils/HTMLTemplates";
 import {
@@ -533,8 +533,8 @@ export default class IFrameNavigator implements Navigator {
         "#reader-loading"
       ) as HTMLDivElement;
       if (this.loadingMessage) {
-        this.loadingMessage.innerHTML = readerLoading;
-        this.loadingMessage.style.display = "none";
+        this.loadingMessage.innerHTML = getReaderLoading();
+        this.loadingMessage.style.display = "none"; 
       }
       this.errorMessage = HTMLUtilities.findElement(
         mainElement,

--- a/src/styles/sass/reader/_loading.scss
+++ b/src/styles/sass/reader/_loading.scss
@@ -19,27 +19,37 @@
  
 @-webkit-keyframes load {
   0% {
-    transform: translate(-2.5rem, -2.5rem) rotate(0deg);
+    transform:  rotate(0deg);
   }
 
   100% {
-    transform: translate(-2.5rem, -2.5rem) rotate(360deg)
+    transform:  rotate(360deg)
   }
 }
 
 @keyframes load {
   0% {
-    transform: translate(-2.5rem, -2.5rem) rotate(0deg);
+    transform:  rotate(0deg);
   }
 
   100% {
-    transform: translate(-2.5rem, -2.5rem) rotate(360deg)
+    transform:  rotate(360deg)
   }
 }
 
 .loading.is-loading {
   .icon {
     animation: load 1s ease-in-out infinite;
+  }
+
+  .center-loading-msg {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    color: #FC601F;
+    font-size: large;
   }
 }
 
@@ -58,13 +68,8 @@
   cursor: default;
 
   .icon {
-    display: block;
-    position: absolute;
-    top: 50%;
-    left: 50%;
     width: 3rem;
     height: 3rem;
-    transform: translate(-50%, -50%);
     fill: $ui-default;
   }
 }

--- a/src/utils/HTMLTemplates.ts
+++ b/src/utils/HTMLTemplates.ts
@@ -41,7 +41,7 @@ export const defaultUpLinkTemplate = (
 </a>
 `;
 
-export const getReaderLoading = () => `${IconLib.icons.loading}<p>Pulling your book from the shelf...</p>`;
+export const getReaderLoading = () => `<div class="center-loading-msg">${IconLib.icons.loading}<p>Pulling your book from the shelf...</p></div>`;
 export const readerError = `
     <span>
     ${IconLib.icons.error}

--- a/src/utils/HTMLTemplates.ts
+++ b/src/utils/HTMLTemplates.ts
@@ -41,7 +41,7 @@ export const defaultUpLinkTemplate = (
 </a>
 `;
 
-export const readerLoading = `${IconLib.icons.loading}`;
+export const getReaderLoading = () => `${IconLib.icons.loading}<p>Pulling your book from the shelf...</p>`;
 export const readerError = `
     <span>
     ${IconLib.icons.error}

--- a/src/utils/HTMLTemplates.ts
+++ b/src/utils/HTMLTemplates.ts
@@ -41,7 +41,8 @@ export const defaultUpLinkTemplate = (
 </a>
 `;
 
-export const getReaderLoading = () => `<div class="center-loading-msg">${IconLib.icons.loading}<p>Pulling your book from the shelf...</p></div>`;
+export const getReaderLoading = (message: string) => `<div class="center-loading-msg">${IconLib.icons.loading}<p>${message}</p></div>`;
+
 export const readerError = `
     <span>
     ${IconLib.icons.error}


### PR DESCRIPTION
Add a loading message under the loading wheel.

One of the oddities of these changes, which I think is related to the cascading nature of css, is that `this.loadingMessage.style.display = none` in the iFrameNavigator is being ignored, meaning that if the message that is passed into the getReaderLoading fn is not the same in that file and in Loading.tsx, the message changes. It might be better not to pass message as a prop, or figure out how to actually `display: none` this intermediate loading state.
The switch to the second loading state is also somewhat noticeable, with a very slight shift of the text/icon up and left.


https://user-images.githubusercontent.com/79113236/144939531-1959de50-4100-4e10-a45c-515580605ea7.mp4


