### PR TITLE
Add safety check to injectables, fix undefined err

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -720,6 +720,15 @@ export async function load(config: ReaderConfig): Promise<any> {
     }
   }
 
+  const getInjectables = () => {
+    let layout = publication.Metadata.Rendition?.Layout ?? 'unknown'
+    if (layout === 'fixed' && config.injectablesFixed) {
+      return config.injectablesFixed
+    } else {
+      return config.injectables
+    }
+  }
+
   // Settings
   D2Settings = await UserSettings.create({
     store: settingsStore,
@@ -727,10 +736,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     headerMenu: headerMenu,
     material: config.material,
     api: config.api,
-    injectables:
-      (publication.Metadata.Rendition?.Layout ?? "unknown") === "fixed"
-        ? config.injectablesFixed
-        : config.injectables,
+    injectables: getInjectables(),
     layout:
       (publication.Metadata.Rendition?.Layout ?? "unknown") === "fixed"
         ? "fixed"
@@ -751,10 +757,7 @@ export async function load(config: ReaderConfig): Promise<any> {
     api: config.api,
     rights: config.rights,
     tts: config.tts,
-    injectables:
-      (publication.Metadata.Rendition?.Layout ?? "unknown") === "fixed"
-        ? config.injectablesFixed
-        : config.injectables,
+    injectables: getInjectables(),
     attributes: config.attributes,
     services: config.services,
   });

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -516,12 +516,10 @@ export default class IFrameNavigator implements Navigator {
           mainElement,
           "main#iframe-wrapper"
         ) as HTMLElement;
-        const minHeight =
-          BrowserUtilities.getHeight() - 40 - this.attributes.margin;
-        wrapper.style.height = minHeight + 40 + "px";
+        wrapper.style.height = this.getWrapperHeight() + "px";
         var iframeParent = this.iframes[0].parentElement
           .parentElement as HTMLElement;
-        iframeParent.style.height = minHeight + 40 + "px";
+        iframeParent.style.height = this.getWrapperHeight() + "px";
       } else {
         if (this.iframes.length == 2) {
           this.iframes.pop();
@@ -1621,6 +1619,7 @@ export default class IFrameNavigator implements Navigator {
         }
 
         this.hideLoadingMessage();
+        this.finalResize()
         this.showIframeContents();
         await this.updatePositionInfo();
       }, 200);
@@ -2131,20 +2130,6 @@ export default class IFrameNavigator implements Navigator {
           }
         }
 
-        var iframeParent =
-          index === 0 && this.iframes.length == 2
-            ? this.iframes[1].parentElement.parentElement
-            : (this.iframes[0].parentElement.parentElement as HTMLElement);
-        var widthRatio =
-          (parseInt(getComputedStyle(iframeParent).width) - 100) /
-          (this.iframes.length == 2
-            ? parseInt(width.replace("px", "")) * 2 + 200
-            : parseInt(width.replace("px", "")));
-        var heightRatio =
-          (parseInt(getComputedStyle(iframeParent).height) - 100) /
-          parseInt(height.replace("px", ""));
-        var scale = Math.min(widthRatio, heightRatio);
-        iframeParent.style.transform = "scale(" + scale + ")";
         for (const iframe of this.iframes) {
           iframe.style.height = height;
           iframe.style.width = width;
@@ -2622,15 +2607,13 @@ export default class IFrameNavigator implements Navigator {
         this.mainElement,
         "main#iframe-wrapper"
       ) as HTMLElement;
-      const minHeight =
-        BrowserUtilities.getHeight() - 40 - this.attributes.margin;
-      wrapper.style.height = minHeight + 40 + "px";
+      wrapper.style.height = this.getWrapperHeight() + "px";
 
       var iframeParent =
         index === 0 && this.iframes.length == 2
           ? this.iframes[1].parentElement.parentElement
           : (this.iframes[0].parentElement.parentElement as HTMLElement);
-      iframeParent.style.height = minHeight + 40 + "px";
+      iframeParent.style.height = this.getWrapperHeight() + "px";
 
       let height = getComputedStyle(
         index === 0 && this.iframes.length == 2
@@ -2667,18 +2650,7 @@ export default class IFrameNavigator implements Navigator {
           }
         }
       }
-
-      var widthRatio =
-        (parseInt(getComputedStyle(iframeParent).width) - 100) /
-        (this.iframes.length == 2
-          ? parseInt(width.replace("px", "")) * 2 + 200
-          : parseInt(width.replace("px", "")));
-      var heightRatio =
-        (parseInt(getComputedStyle(iframeParent).height) - 100) /
-        parseInt(height.replace("px", ""));
-      var scale = Math.min(widthRatio, heightRatio);
-      iframeParent.style.transform = "scale(" + scale + ")";
-
+      this.finalResize()
       for (const iframe of this.iframes) {
         iframe.style.height = height;
         iframe.style.width = width;
@@ -3205,6 +3177,43 @@ export default class IFrameNavigator implements Navigator {
       if (this.api?.resourceAtStart) this.api?.resourceAtStart();
     }
   }, 200);
+
+  private finalResize() {
+    if (
+      (this.publication.Metadata.Rendition?.Layout ?? "unknown") === "fixed"
+    ) {
+      const innerDoc = this.iframes[0].contentDocument ? this.iframes[0].contentDocument : this.iframes[0].contentWindow.document
+      const body = innerDoc.children[0].children[1] as HTMLElement;
+      const page = body.firstElementChild as HTMLElement
+      if (page) {
+        page.style.height = this.getGraphicNovelAspectRatio().height + "px"
+        page.style.width = this.getGraphicNovelAspectRatio().width + "px"
+      }
+  }
+  }
+
+  private getGraphicNovelAspectRatio() {
+    const maxWidth = parseInt(getComputedStyle(this.iframes[0].contentDocument.body).width, 10)
+    const optimalHeight = (1024* maxWidth)/663
+    const maxHeight = this.getWrapperHeight()
+    const optimalWidth = (663* maxHeight) /1024
+    
+    if (optimalHeight < maxHeight) {
+      return {
+        width: maxWidth,
+        height: optimalHeight
+      }
+    } else {
+      return {
+        width: optimalWidth,
+        height: maxHeight
+      }
+    }
+  }
+
+  private getWrapperHeight() {
+    return Number(BrowserUtilities.getHeight() - 40 - this.attributes.margin) + 40;
+  }
 
   private showIframeContents() {
     this.isBeingStyled = false;

--- a/src/navigator/IFrameNavigator.ts
+++ b/src/navigator/IFrameNavigator.ts
@@ -516,10 +516,10 @@ export default class IFrameNavigator implements Navigator {
           mainElement,
           "main#iframe-wrapper"
         ) as HTMLElement;
-        wrapper.style.height = this.getWrapperHeight() + "px";
+        wrapper.style.height = this.getIframeWrapperHeight() + "px";
         var iframeParent = this.iframes[0].parentElement
           .parentElement as HTMLElement;
-        iframeParent.style.height = this.getWrapperHeight() + "px";
+        iframeParent.style.height = this.getIframeWrapperHeight() + "px";
       } else {
         if (this.iframes.length == 2) {
           this.iframes.pop();
@@ -2607,13 +2607,13 @@ export default class IFrameNavigator implements Navigator {
         this.mainElement,
         "main#iframe-wrapper"
       ) as HTMLElement;
-      wrapper.style.height = this.getWrapperHeight() + "px";
+      wrapper.style.height = this.getIframeWrapperHeight() + "px";
 
       var iframeParent =
         index === 0 && this.iframes.length == 2
           ? this.iframes[1].parentElement.parentElement
           : (this.iframes[0].parentElement.parentElement as HTMLElement);
-      iframeParent.style.height = this.getWrapperHeight() + "px";
+      iframeParent.style.height = this.getIframeWrapperHeight() + "px";
 
       let height = getComputedStyle(
         index === 0 && this.iframes.length == 2
@@ -3186,16 +3186,16 @@ export default class IFrameNavigator implements Navigator {
       const body = innerDoc.children[0].children[1] as HTMLElement;
       const page = body.firstElementChild as HTMLElement
       if (page) {
-        page.style.height = this.getGraphicNovelAspectRatio().height + "px"
-        page.style.width = this.getGraphicNovelAspectRatio().width + "px"
+        page.style.height = this.getFixedLayoutWidthAndHeight().height + "px"
+        page.style.width = this.getFixedLayoutWidthAndHeight().width + "px"
       }
   }
   }
 
-  private getGraphicNovelAspectRatio() {
+  private getFixedLayoutWidthAndHeight() {
     const maxWidth = parseInt(getComputedStyle(this.iframes[0].contentDocument.body).width, 10)
     const optimalHeight = (1024* maxWidth)/663
-    const maxHeight = this.getWrapperHeight()
+    const maxHeight = this.getIframeWrapperHeight()
     const optimalWidth = (663* maxHeight) /1024
     
     if (optimalHeight < maxHeight) {
@@ -3211,7 +3211,7 @@ export default class IFrameNavigator implements Navigator {
     }
   }
 
-  private getWrapperHeight() {
+  private getIframeWrapperHeight() {
     return Number(BrowserUtilities.getHeight() - 40 - this.attributes.margin) + 40;
   }
 


### PR DESCRIPTION
Add getInjectables() fn that checks for injectablesFixed and falls back to injectables. Fixes bug where this.injectables was undefined.

Also fixes odd image cropping when graphic novels are uploaded as epubs. Because the page size is not forced with an epub, I resize the height/width of the page to fit the standard american comic book aspect ratio of 663:1024. This sizing is applied when the epub first loads as well as when it is resized. See [video](https://user-images.githubusercontent.com/79113236/148621936-4ae26ace-25a6-48c8-931d-f4da7e4164d4.mp4
)

Some future notes/issues related to this card:
- All of my changes are conditional on `(this.publication.Metadata.Rendition?.Layout ?? "unknown") === "fixed"` because (at least for the three isbns Justin identified for this bug), the Layout was "fixed." I tested these changes by opening up Downeast (a regular epub) and it is unaffected since it does not have a fixed layout.  Hopefully this doesn't introduce any bugs down the line... Maybe there is a better way to discern whether a graphic novel has been uploaded as an epub than `"fixed === "fixed"`?
- Since publishers will inevitably upload graphic novels as epubs, the last few bullet points are some other thoughts for how to make the reader experience better in that case.  However maybe there is a way to encourage publishers at upload time to prefer pdfs for graphic novels or image-heavy children's books?
- [Text flow should be set to 1 column](https://dev.azure.com/abovethetreeline/Edelweiss%20Reader/_boards/board/t/Edelweiss%20Reader%20Team/Stories/?workitem=9039) by default for this format, auto pushes the image to the side on larger screen sizes (you can see this in my video)
- [Clicking `reset` in the settings drawer leads to this.spreads undefined error](https://dev.azure.com/abovethetreeline/Edelweiss%20Reader/_boards/board/t/Edelweiss%20Reader%20Team/Stories/?workitem=9038)
- [None of the settings work](https://dev.azure.com/abovethetreeline/Edelweiss%20Reader/_boards/board/t/Edelweiss%20Reader%20Team/Stories/?workitem=9040) anyway since graphic novels don't have reflowable text, so maybe we should remove the settings drawer for this type of file

